### PR TITLE
Add stylefmt object to each file processed, and a "fixed" property to…

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,14 @@ module.exports = function (options) {
     }
 
     var self = this
+    var contents = file.contents.toString()
+
     postcss([stylefmt(options)])
-      .process(file.contents.toString(), { syntax: scss })
+      .process(contents, { syntax: scss })
       .then(function (result) {
+        file.stylefmt = {
+          fixed: contents !== result.css
+        }
         file.contents = new Buffer(result.css);
         self.push(file);
         cb();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-stylefmt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "gulp plugin for stylefmt",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ it('stylefmt', function (cb) {
     .then(function (result) {
       stream.on('data', function (file) {
         assert.equal(file.contents.toString(), output);
+        assert.isTrue(file.stylefmt.fixed)
       });
 
       stream.write(new gutil.File({


### PR DESCRIPTION
… show whether stylefmt made changes to that file.

This is especially useful for automating auto-formatting tasks so we know when to stop writing a SCSS file to its destination and thus prevent an infinite loop.

Follows the same object format as ESLint.